### PR TITLE
Add Star Citizen IVO animation support (CAF/DBA)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This repository contains 010 Editor binary templates (.bt files) for analyzing CryEngine, Lumberyard, and Open 3D Engine (O3DE) game asset files. These templates parse binary file formats used by games like MechWarrior Online, ArcheAge, Hunt: Showdown, and Star Citizen.
+
+010 Editor: https://www.sweetscape.com/010editor/
+
+## Template Architecture
+
+### Entry Points
+
+Three main entry point templates exist for different file formats:
+
+- **Cryengine.bt** - Universal entry point that auto-detects file type via magic bytes:
+  - `CryT` = CryEngine 3.4 format (MWO, ArcheAge)
+  - `CrCh` = CryEngine 3.8 format (Hunt: Showdown)
+  - `#ivo` = Star Citizen custom format (redirects to CryEngine-Ivo.bt)
+
+- **CryEngine-Ivo.bt** - Dedicated parser for Star Citizen #ivo files with different chunk structure
+
+- **CryEngine-CryXmlB.bt** / **Cryengine-pbxml.bt** - Binary XML format parsers
+
+### Shared Module Structure
+
+Templates use `#include` directives and header guards (`#ifndef/#define/#endif`) for modularity:
+
+| File | Purpose |
+|------|---------|
+| `Cryengine-BaseTypes.bt` | Primitive types (VECTOR3, QUATERNION, MATRIX3x4, etc.) with custom read functions for normalized types (snorm, unorm) |
+| `Cryengine-Enums.bt` | Chunk types (CHUNKTYPE_UI, CHUNKTYPE_US), data stream types, vertex formats, compression formats |
+| `Cryengine-Structs.bt` | Main data structures (HEADER, CHUNKTABLE, MESHCHUNK, COMPILEDBONE, CONTROLLER_829/905, etc.) |
+| `Cryengine-Helpers.bt` | Print/comment functions for displaying parsed data in 010 Editor |
+| `Cryengine-Common.bt` | Shared utilities like CryHalfToFloat conversion |
+
+Star Citizen #ivo files have parallel modules:
+- `CryengineIvo-Enums.bt` - Different chunk types (0x-prefixed identifiers from reverse engineering)
+- `CryengineIvo-Structs.bt` - Ivo-specific structures (SKINMESH, NODEMESHCOMBOCHUNK, etc.)
+- `CryengineIvo-Helpers.bt` - Ivo-specific print functions
+
+### Key Patterns
+
+1. **Version-aware parsing**: Structures accept `FILETYPE` or version parameters to handle format differences:
+   ```c
+   struct HEADER(FILETYPE fileType) {
+       if (fileType == CRYENGINE_3_4) { ... }
+       else if (fileType == CRYENGINE_3_8) { ... }
+   }
+   ```
+
+2. **Chunk-based format**: Files contain a header with chunk table, then chunks at specified offsets. Main parsing loop iterates chunk table and switches on chunk type.
+
+3. **Big/Little Endian handling**: Some formats (version 0x80000800) require `BigEndian()`/`LittleEndian()` toggling.
+
+4. **Comment functions**: Every major struct has a corresponding `Print*` function for 010 Editor display (e.g., `PrintVector3`, `PrintBoneName`).
+
+## Development Notes
+
+- When adding new chunk types, update both the enum and add a case in the main switch statement
+- Ivo datastream types are identified by magic uint32 values (e.g., `0x91329AE9` = IvoVertsUvs)
+- Alignment helpers exist: `AlignTo4()`, `AlignTo8ByteBoundary()`
+- Use `<comment=FunctionName>` and `<bgcolor=color>` attributes for 010 Editor visualization
+
+## Planned Work (from README)
+
+- Consolidate the 3 entry points into a single root template
+- Split structs and common functions into more logical structure

--- a/CryEngine-Ivo.bt
+++ b/CryEngine-Ivo.bt
@@ -1,14 +1,16 @@
 //------------------------------------------------
 //--- 010 Editor v11.0 Binary Template
 //
-//      File: 
+//      File: CryEngine-Ivo.bt
 //   Authors: Geoffrey Gerber
-//   Version: 0.1
-//   Purpose: Star Citizen #ivo files
+//   Version: 0.2
+//   Purpose: Star Citizen #ivo files (CGF, SKIN, CAF, DBA)
 //  Category: Games
-// File Mask: #ivo
-//  ID Bytes: 4
-//   History: 
+// File Mask: *.cgf, *.skin, *.caf, *.dba
+//  ID Bytes: 23 69 76 6F
+//   History:
+//     0.2 - Added CAF and DBA animation support
+//     0.1 - Initial version
 //------------------------------------------------
 
 // Ivo files
@@ -16,9 +18,11 @@
 #include "CryengineIvo-Enums.bt"
 #include "CryengineIvo-Structs.bt"
 #include "CryengineIvo-Helpers.bt"
+#include "CryEngineIvo-Animation.bt"
 
 local uint pos;
-local int64 fileSize = FileSize() ;
+local int64 fileSize = FileSize();
+local char animSig[4];
 
 HEADER headerInfo <bgcolor=cLtBlue>;
 
@@ -70,7 +74,31 @@ for (index = 0; index < headerInfo.numChunks; index++) {
             NODEMESHCOMBOCHUNK NodeMeshCombo <bgcolor=cLtBlue>;
             break;
         };
+        case AnimationInfo: {
+            ANIM_INFO_CHUNK animInfo <bgcolor=cLtYellow, comment=PrintAnimInfo>;
+            break;
+        };
+        case CAFData: {
+            CAF_CHUNK cafChunk <bgcolor=cLtPurple, comment=PrintCAFChunk>;
+            break;
+        };
+        case DBAData: {
+            DBA_DATA_CHUNK dbaDataChunk <bgcolor=cDkAqua, comment=PrintDBADataChunk>;
+            break;
+        };
+        case DBA: {
+            DBA_METADATA_CHUNK dbaMetadataChunk <bgcolor=cLtRed, comment=PrintDBAMetadataChunk>;
+            break;
+        };
         default: {
+            // Check for #caf or #dba signature in case chunk type ID doesn't match enum
+            ReadBytes(animSig, FTell(), 4);
+            if (animSig[0] == '#' && animSig[1] == 'c' && animSig[2] == 'a' && animSig[3] == 'f') {
+                CAF_CHUNK cafChunk <bgcolor=cLtPurple, comment=PrintCAFChunk>;
+            }
+            else if (animSig[0] == '#' && animSig[1] == 'd' && animSig[2] == 'b' && animSig[3] == 'a') {
+                DBA_ANIMATION_BLOCK dbaBlock <bgcolor=cDkAqua, comment=PrintDBABlock>;
+            }
             break;
         }
     }

--- a/CryEngineIvo-Animation.bt
+++ b/CryEngineIvo-Animation.bt
@@ -1,0 +1,251 @@
+//------------------------------------------------
+//--- 010 Editor v13.0.2 Binary Template
+//
+//      File: CryEngineIvo-Animation.bt
+//   Authors: Geoff Gerber
+//   Version: 0.2
+//   Purpose: Star Citizen IVO CAF/DBA Animation File structures
+//  Category: Games
+// File Mask: *.caf, *.dba
+//  ID Bytes:
+//   History:
+//     0.2 - Added DBA support
+//     0.1 - Initial CAF support
+//------------------------------------------------
+
+#ifndef ANIMATION_IVO_H
+#define ANIMATION_IVO_H
+
+#include "Cryengine-BaseTypes.bt"
+#include "CryengineIvo-Enums.bt"
+
+//===========================================
+// Animation Info Chunk (CAF files, Version 0x0901)
+// Size: 48 bytes (0x30)
+//===========================================
+struct ANIM_INFO_CHUNK {
+    uint32   flags;              // Usually 2
+    uint16   unknown1;           // Varies
+    uint16   numBones;           // Number of bones
+    uint32   unknown2;           // Usually 0
+    uint32   numPositionTracks;  // Number of bones with position data
+
+    // Bounding/scale values
+    float    boundMin[3];        // Bounding box min or special values
+    float    scale;              // Scale factor (~1.0)
+
+    // Precision value
+    double   precision;          // Very small double value
+
+    uint32   padding[2];         // Padding/reserved (zeros)
+};
+
+//===========================================
+// Controller Entry (shared by #caf and #dba)
+// Size: 24 bytes each
+//
+// Format Flags:
+//   High byte: 0x80 = rotation only, 0xC0 = has position
+//   Low byte compression format:
+//     0x42 = SmallTree48BitQuat (6 bytes/key)
+//     0x43 = SmallTree64BitQuat (8 bytes/key)
+//     0x00 = NoCompressQuat (16 bytes/key)
+//===========================================
+struct ANIM_CONTROLLER_ENTRY {
+    ubyte    numKeys;            // Number of keyframes
+    ubyte    padding;            // Always 0
+    uint16   formatFlags;        // 0x8042 = rot only, 0xC242 = has position
+    uint32   rotDataOffset;      // Offset to rotation data (relative)
+    uint32   rotTimeOffset;      // Offset to rotation time keys
+    uint32   posDataOffset;      // Offset to position data (0 if none)
+    uint32   posTimeOffset;      // Offset to position time keys (0 if none)
+    uint32   reserved;           // Reserved/padding
+};
+
+//===========================================
+// #caf / #dba Block Header (12 bytes)
+//===========================================
+struct ANIM_BLOCK_HEADER {
+    char     signature[4];       // "#caf" or "#dba"
+    ubyte    boneCount;          // Number of bones
+    ubyte    padding;            // Always 0
+    uint16   magic;              // 0xAA55
+    uint32   dataSize;           // Total size of block data (after header)
+};
+
+//===========================================
+// #caf Animation Block (single animation)
+//===========================================
+struct CAF_CHUNK {
+    ANIM_BLOCK_HEADER header <bgcolor=cLtBlue, comment=PrintAnimBlockHeader>;
+
+    local int numBones = header.boneCount;
+    local int64 blockStart = FTell() - 12;
+
+    // Bone hash array (CRC32 of bone names)
+    uint32 boneHashes[numBones] <bgcolor=cLtGreen, comment="CRC32 bone identifiers">;
+
+    // Controller entries
+    ANIM_CONTROLLER_ENTRY controllers[numBones] <bgcolor=cLtYellow, comment=PrintControllerEntry>;
+
+    // Keyframe data
+    local int64 blockEnd = blockStart + 12 + header.dataSize;
+    local int keyframeDataSize = blockEnd - FTell();
+    if (keyframeDataSize > 0) {
+        ubyte keyframeData[keyframeDataSize] <bgcolor=cSilver, comment="Compressed keyframe data">;
+    }
+};
+
+//===========================================
+// #dba Animation Block (one animation in library)
+//===========================================
+struct DBA_ANIMATION_BLOCK {
+    ANIM_BLOCK_HEADER header <bgcolor=cLtBlue, comment=PrintAnimBlockHeader>;
+
+    local int numBones = header.boneCount;
+    local int64 blockStart = FTell() - 12;
+
+    // Bone hash array (CRC32 of bone names)
+    uint32 boneHashes[numBones] <bgcolor=cLtPurple, comment="CRC32 bone identifiers">;
+
+    // Controller entries
+    ANIM_CONTROLLER_ENTRY controllers[numBones] <bgcolor=cLtYellow, comment=PrintControllerEntry>;
+
+    // Keyframe data
+    local int64 blockEnd = blockStart + 12 + header.dataSize;
+    local int keyframeDataSize = blockEnd - FTell();
+    if (keyframeDataSize > 0) {
+        ubyte keyframeData[keyframeDataSize] <bgcolor=cDkGray, comment="Compressed keyframe data">;
+    }
+};
+
+//===========================================
+// DBA Data Chunk (contains multiple #dba blocks)
+// Chunk ID: 0x194FBC50 (DBAData)
+//===========================================
+struct DBA_DATA_CHUNK {
+    uint32 totalDataSize <comment="Total size of all animation blocks">;
+
+    local int64 dataEnd = FTell() + totalDataSize - 4;
+    local int animIndex = 0;
+    local char sig[4];
+
+    // Parse #dba blocks until we reach the end
+    while (FTell() < dataEnd) {
+        ReadBytes(sig, FTell(), 4);
+        if (sig[0] == '#' && sig[1] == 'd' && sig[2] == 'b' && sig[3] == 'a') {
+            DBA_ANIMATION_BLOCK animation <comment=PrintDBABlock>;
+            animIndex++;
+        } else {
+            break;
+        }
+    }
+};
+
+//===========================================
+// DBA Metadata Entry (44 bytes each)
+// Note: All entries appear to be same size
+//===========================================
+struct DBA_META_ENTRY {
+    uint16   numKeys;            // Number of keyframes
+    uint16   boneCount;          // Number of bones
+    uint32   flags;              // Animation flags
+    uint32   pathLength;         // Length of path string
+    VECTOR3  startPosition;      // Start position
+    QUATERNION startRotation;    // Start rotation
+    uint32   padding;            // Padding/reserved
+};
+
+//===========================================
+// Animation Path String (null-terminated)
+//===========================================
+struct ANIM_PATH_STRING {
+    string path;
+};
+
+//===========================================
+// DBA Metadata Chunk
+// Chunk ID: 0xF7351608 (DBA)
+//===========================================
+struct DBA_METADATA_CHUNK {
+    uint32 animCount <comment="Number of animations in library">;
+    uint32 reserved;
+
+    // All entries are 44 bytes
+    DBA_META_ENTRY entries[animCount] <bgcolor=cLtRed, comment=PrintDBAMetaEntry>;
+
+    // String table - null-terminated animation paths
+    local int i;
+    for (i = 0; i < animCount; i++) {
+        ANIM_PATH_STRING animPath <bgcolor=cWhite, comment=PrintAnimPath>;
+    }
+};
+
+//===========================================
+// Helper/Print Functions
+//===========================================
+string PrintAnimInfo(ANIM_INFO_CHUNK &info) {
+    string result;
+    SPrintf(result, "Bones: %d, PosTracks: %d, Scale: %f",
+        info.numBones, info.numPositionTracks, info.scale);
+    return result;
+};
+
+string PrintAnimBlockHeader(ANIM_BLOCK_HEADER &hdr) {
+    string result;
+    SPrintf(result, "%c%c%c%c Bones: %d, Magic: 0x%04X, Size: %d",
+        hdr.signature[0], hdr.signature[1], hdr.signature[2], hdr.signature[3],
+        hdr.boneCount, hdr.magic, hdr.dataSize);
+    return result;
+};
+
+string PrintControllerEntry(ANIM_CONTROLLER_ENTRY &ctrl) {
+    string result;
+    if ((ctrl.formatFlags & 0xC000) == 0xC000) {
+        SPrintf(result, "Keys:%d Fmt:0x%04X Rot@0x%X Pos@0x%X",
+            ctrl.numKeys, ctrl.formatFlags, ctrl.rotDataOffset, ctrl.posDataOffset);
+    } else {
+        SPrintf(result, "Keys:%d Fmt:0x%04X Rot@0x%X (no pos)",
+            ctrl.numKeys, ctrl.formatFlags, ctrl.rotDataOffset);
+    }
+    return result;
+};
+
+string PrintCAFChunk(CAF_CHUNK &caf) {
+    string result;
+    SPrintf(result, "#caf - %d bones, %d bytes",
+        caf.header.boneCount, caf.header.dataSize);
+    return result;
+};
+
+string PrintDBABlock(DBA_ANIMATION_BLOCK &dba) {
+    string result;
+    SPrintf(result, "#dba - %d bones, %d bytes",
+        dba.header.boneCount, dba.header.dataSize);
+    return result;
+};
+
+string PrintDBAMetaEntry(DBA_META_ENTRY &entry) {
+    string result;
+    SPrintf(result, "Keys:%d Bones:%d PathLen:%d",
+        entry.numKeys, entry.boneCount, entry.pathLength);
+    return result;
+};
+
+string PrintDBADataChunk(DBA_DATA_CHUNK &chunk) {
+    string result;
+    SPrintf(result, "DBA Data: %d bytes", chunk.totalDataSize);
+    return result;
+};
+
+string PrintDBAMetadataChunk(DBA_METADATA_CHUNK &chunk) {
+    string result;
+    SPrintf(result, "DBA Metadata: %d animations", chunk.animCount);
+    return result;
+};
+
+string PrintAnimPath(ANIM_PATH_STRING &p) {
+    return p.path;
+};
+
+#endif

--- a/CryengineIvo-Enums.bt
+++ b/CryengineIvo-Enums.bt
@@ -48,6 +48,9 @@ enum <uint> CHUNKTYPE {
     U13_BShapesGPU          = 0x57a38888, // 1405e9863(SKINM), v900h
     U14_SimDeformation      = 0xff277a9a, // 1405e987b(SKINM), v900h
     U15_VisAreas            = 0xb32459d2, // 1405e8c93(SKINM2), v900h
+    // Animation chunks (CAF files) - chunk type IDs need verification from actual files
+    AnimationInfo           = 0x4733c6ed, // Animation info chunk, v901h (placeholder ID)
+    CAFData                 = 0xa9496cb5, // #caf animation data chunk, v900h ("#caf" as uint32 LE)
 };
 
 enum VERTEXFORMAT {

--- a/StarCitizen_DBA_Format.md
+++ b/StarCitizen_DBA_Format.md
@@ -1,0 +1,250 @@
+# Star Citizen DBA Animation Library Format
+
+## Overview
+
+Star Citizen uses a custom animation format based on CryEngine, wrapped in an `#ivo` container format. DBA (Database Animation) files contain multiple animations bundled together for efficient loading.
+
+**File analyzed:** `ursa.dba` - Contains 22 animations for the RSI Ursa Rover vehicle
+
+## File Structure
+
+```
+#ivo Container
+├── Header (16 bytes)
+├── Chunk Table (16 bytes × numChunks)
+├── Chunk 0: Animation Data (#dba blocks)
+│   ├── Total chunk size (4 bytes)
+│   ├── #dba Block 1
+│   ├── #dba Block 2
+│   └── ... (one per animation)
+└── Chunk 1: Animation Metadata
+    ├── Header (8 bytes)
+    ├── Animation Entries (44 bytes each, last is 40)
+    └── String Table (null-terminated paths)
+```
+
+---
+
+## #ivo Container Header
+
+| Offset | Size | Type     | Description              | Example Value |
+|--------|------|----------|--------------------------|---------------|
+| 0x00   | 4    | char[4]  | Signature                | "#ivo"        |
+| 0x04   | 2    | uint16   | Version (little endian)  | 0x0900        |
+| 0x06   | 2    | uint16   | Reserved                 | 0x0000        |
+| 0x08   | 4    | uint32   | Number of chunks         | 2             |
+| 0x0C   | 4    | uint32   | Header size              | 0x10          |
+
+## Chunk Table Entry (16 bytes each)
+
+| Offset | Size | Type   | Description        |
+|--------|------|--------|--------------------|
+| 0x00   | 4    | uint32 | Chunk ID           |
+| 0x04   | 2    | uint16 | Version            |
+| 0x06   | 2    | uint16 | Reserved           |
+| 0x08   | 4    | uint32 | Offset from file start |
+| 0x0C   | 4    | uint32 | Reserved           |
+
+### Known Chunk IDs
+
+| Chunk ID     | Version | Description                    |
+|--------------|---------|--------------------------------|
+| 0x194FBC50   | 0x0900  | Animation Data (contains #dba) |
+| 0xF7351608   | 0x0901  | Animation Metadata             |
+
+---
+
+## Chunk 0: Animation Data
+
+### Chunk 0 Header
+
+| Offset | Size | Type   | Description                    |
+|--------|------|--------|--------------------------------|
+| 0x00   | 4    | uint32 | Total chunk data size (bytes)  |
+
+After this 4-byte size field, the animation blocks follow consecutively.
+
+### #dba Animation Block
+
+Each animation in the DBA is stored as a `#dba` block:
+
+| Offset | Size | Type     | Description              |
+|--------|------|----------|--------------------------|
+| 0x00   | 4    | char[4]  | Signature "#dba"         |
+| 0x04   | 1    | uint8    | Bone count               |
+| 0x05   | 1    | uint8    | Padding (always 0)       |
+| 0x06   | 2    | uint16   | Magic marker (0xAA55)    |
+| 0x08   | 4    | uint32   | Animation data size      |
+| 0x0C   | var  | uint32[] | Bone hash array          |
+| var    | var  | struct[] | Controller entries       |
+| var    | var  | bytes    | Keyframe data            |
+
+**Bone Hash Array:** `boneCount × 4 bytes` (CRC32 hashes of bone names)
+
+**Controller Entries:** `boneCount × 24 bytes`
+
+### Controller Entry (24 bytes)
+
+| Offset | Size | Type   | Description               |
+|--------|------|--------|---------------------------|
+| 0x00   | 1    | uint8  | Number of keyframes       |
+| 0x01   | 1    | uint8  | Padding                   |
+| 0x02   | 2    | uint16 | Format flags              |
+| 0x04   | 4    | uint32 | Rotation data offset      |
+| 0x08   | 4    | uint32 | Rotation time offset      |
+| 0x0C   | 4    | uint32 | Position data offset      |
+| 0x10   | 4    | uint32 | Position time offset      |
+| 0x14   | 4    | uint32 | Reserved                  |
+
+### Format Flags
+
+The format flags field (2 bytes) encodes compression information:
+
+| Bit Pattern | Meaning                    |
+|-------------|----------------------------|
+| 0x8042      | Rotation only, SmallTree48 |
+| 0xC242      | Has position, SmallTree48  |
+| 0x80xx      | Rotation only flag         |
+| 0xC0xx      | Has position flag          |
+
+**Rotation Compression Formats** (low byte):
+- 0x42 = SmallTree48BitQuat (6 bytes per key)
+- 0x43 = SmallTree64BitQuat (8 bytes per key)
+- 0x00 = NoCompressQuat (16 bytes per key)
+
+**Position Compression Formats:**
+- Similar to CAF controller formats
+
+### Keyframe Data Layout
+
+For each bone controller, keyframe data is stored at the specified offsets:
+
+1. **Rotation values:** `numKeys × compressionSize` bytes
+2. **Rotation times:** `numKeys × timeFormat` bytes
+3. **Position values:** (if present) `numKeys × posFormat` bytes
+4. **Position times:** (if present) `numKeys × timeFormat` bytes
+
+---
+
+## Chunk 1: Animation Metadata
+
+### Metadata Header
+
+| Offset | Size | Type   | Description        |
+|--------|------|--------|--------------------|
+| 0x00   | 4    | uint32 | Animation count    |
+| 0x04   | 4    | uint32 | Reserved           |
+
+### Animation Entry (44 bytes, last entry is 40 bytes)
+
+| Offset | Size | Type    | Description               |
+|--------|------|---------|---------------------------|
+| 0x00   | 2    | uint16  | Number of keys/frames     |
+| 0x02   | 2    | uint16  | Bone count                |
+| 0x04   | 4    | uint32  | Flags                     |
+| 0x08   | 4    | uint32  | Path length               |
+| 0x0C   | 12   | Vec3    | Start position (x,y,z)    |
+| 0x18   | 16   | Quat    | Start rotation (x,y,z,w)  |
+| 0x28   | 4    | uint32  | Extra field (padding)*    |
+
+*The last entry in the array does not have the 4-byte extra field.
+
+### String Table
+
+Immediately after the animation entries, null-terminated animation paths are stored consecutively:
+
+```
+animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_gunner_enter.caf\0
+animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_gunner_exit.caf\0
+...
+```
+
+---
+
+## Example: ursa.dba Analysis
+
+**File size:** 2,682,360 bytes
+
+**Animations (22 total):**
+| Index | Bones | Keys | Path |
+|-------|-------|------|------|
+| 0     | 112   | 30   | rsi_ursa_rover_gunner_enter.caf |
+| 1     | 112   | 30   | rsi_ursa_rover_gunner_exit.caf |
+| 2     | 107   | 30   | rsi_ursa_rover_gunner_idle.caf |
+| 3     | 107   | 30   | rsi_ursa_rover_gunner_mobiglas_enter.caf |
+| ...   | ...   | ...  | ... |
+| 21    | 116   | 30   | rsi_ursa_rover_pilot_steer_fullrange.caf |
+
+---
+
+## Differences from Standard CryEngine/Lumberyard
+
+1. **Container format:** Uses `#ivo` instead of standard CryEngine chunk headers
+2. **Inline bone hashes:** DBA blocks include bone CRC32 hashes directly
+3. **Simplified controller:** 24-byte controller entries vs Lumberyard's variable structures
+4. **Magic marker:** `0xAA55` marker after bone count
+
+---
+
+## CAF vs DBA Chunk IDs
+
+Star Citizen uses different chunk IDs for CAF (single animation) and DBA (animation library) files:
+
+| File Type | Chunk ID     | Description           |
+|-----------|--------------|----------------------|
+| **DBA**   | 0x194FBC50   | Animation Data       |
+| **DBA**   | 0xF7351608   | Animation Metadata   |
+| **CAF**   | 0x47338DD8   | Animation Data       |
+| **CAF**   | 0xD8496CA8   | Animation Info       |
+
+---
+
+## 010 Editor Templates
+
+Two 010 Editor templates are provided:
+
+1. **StarCitizen_DBA.bt** - Specialized template for DBA files
+2. **StarCitizen_IVO.bt** - Universal template supporting both CAF and DBA
+
+To use:
+1. Open the .dba or .caf file in 010 Editor
+2. Run the template (Templates > Run Template)
+3. Navigate the parsed structure in the Template Results panel
+
+---
+
+## Related Formats
+
+- **Star Citizen CAF:** Single animation files using same `#ivo` container
+- **Lumberyard DBA:** Standard CryEngine v0905 animation library format
+- **Lumberyard CAF:** Standard CryEngine animation format (v0829, v0831)
+
+---
+
+## Appendix: Full Animation List (ursa.dba)
+
+| # | Bones | Animation Path |
+|---|-------|----------------|
+| 0 | 112 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_gunner_enter.caf |
+| 1 | 112 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_gunner_exit.caf |
+| 2 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_gunner_idle.caf |
+| 3 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_gunner_mobiglas_enter.caf |
+| 4 | 108 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_gunner_mobiglas_exit.caf |
+| 5 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_gunner_mobiglas_idle.caf |
+| 6 | 111 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_enter.caf |
+| 7 | 112 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_exit.caf |
+| 8 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_gforce_forward.caf |
+| 9 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_gforce_forward_high.caf |
+| 10 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_gforce_leftbank.caf |
+| 11 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_gforce_leftbank_high.caf |
+| 12 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_gforce_reverse.caf |
+| 13 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_gforce_reverse_high.caf |
+| 14 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_gforce_rightbank.caf |
+| 15 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_gforce_rightbank_high.caf |
+| 16 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_idle.caf |
+| 17 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_idledriving.caf |
+| 18 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_mobiglas_enter.caf |
+| 19 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_mobiglas_exit.caf |
+| 20 | 107 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_mobiglas_idle.caf |
+| 21 | 116 | animations/characters/human/male_v7/vehicles/rsi/ursa/rsi_ursa_rover_pilot_steer_fullrange.caf |
+


### PR DESCRIPTION
- Add CryEngineIvo-Animation.bt with CAF and DBA animation structures
- Update CryEngine-Ivo.bt to handle animation chunks (CAFData, DBAData, DBA)
- Add animation chunk type IDs to CryengineIvo-Enums.bt
- Add CLAUDE.md for Claude Code guidance
- Add StarCitizen_DBA_Format.md with format analysis

Structures added:
- ANIM_BLOCK_HEADER: 12-byte header for #caf/#dba blocks
- ANIM_CONTROLLER_ENTRY: 24-byte per-bone controller
- CAF_CHUNK: Single animation parser
- DBA_ANIMATION_BLOCK: Animation block in DBA library
- DBA_DATA_CHUNK: Container for multiple #dba blocks
- DBA_META_ENTRY: 44-byte metadata entry
- DBA_METADATA_CHUNK: Metadata with string table
- ANIM_INFO_CHUNK: 48-byte CAF animation info

🤖 Generated with [Claude Code](https://claude.com/claude-code)